### PR TITLE
Default headless option to the 'new' flag to remove deprecation warning.

### DIFF
--- a/lib/get_tweets.js
+++ b/lib/get_tweets.js
@@ -7,7 +7,7 @@ const debug = require('debug')('recent-tweets')
 
 const getTweets = async (username, options = {}) => {
   // Parse options
-  const headless = options.headless !== false
+  const headless = options.headless || 'new'
   const deviceDescriptor = options.deviceDescriptor || 'iPhone 11 Pro Max'
   const expandShortlinks = options.expandShortlinks || false
 


### PR DESCRIPTION
Get this warning without any output from the tweets when using. Looks like we need to pass this `new` option instead when we want headless, but this will just allow us to pass through any other option.

<img width="1034" alt="Screenshot 2023-05-24 at 19 59 43" src="https://github.com/huned/nodejs-recent-tweets/assets/2669541/a0f4d9eb-919c-4483-9171-a3cca0f8f399">

https://www.selenium.dev/blog/2023/headless-is-going-away/